### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "fs-extra": "~0.18.4",
         "jade": "~0.35.0",
         "mincer": "~1.2.4",
-        "node-sass": "~3.1.2",
+        "node-sass": "~3.3.3",
         "node-schedule": "~0.2.8",
         "prompt": "~0.2.14",
         "request": "~2.57.0",


### PR DESCRIPTION
Update `node-sass` version, this fix installation failed when using Node version 4.0.0

> npm ERR! node-sass@3.1.2 postinstall: `node scripts/build.js`
> npm ERR! Exit status 1
> npm ERR! 
> npm ERR! Failed at the node-sass@3.1.2 postinstall script 'node scripts/build.js'.
